### PR TITLE
fix: fpermissive error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ if use_kwargs:
 # isn't windows, g++ will be used; -Wno-unused then would suppress some annoying warnings
 # about the Box2D source.
 if sys.platform in ('win32', 'win64'):
-    extra_args=['-I.']
+    extra_args=['-I.', '-fpermissive']
 else:
     extra_args=['-I.', '-Wno-unused']
 


### PR DESCRIPTION
Currenty Gym environments based on Box2D fails to install on Windows 10/Anaconda 4.7+. The reason for this is the new GCC 5.3 that gets installed with latest Anaconda. These newer versions have `-fno-permissive` option by default which causes compile errors on any code where casts may cause loss on precision. Unfortunately, Box2D code is full of these casts and so its installation errors out. The current pull requests adds `-fermissive` in to GCC option to make it backward compatible for this error so it can get installed successfully.

Related issue on pybox2d: https://github.com/pybox2d/pybox2d/issues/111
Same PR on pybox2d: https://github.com/pybox2d/pybox2d/pull/112
Related issue on Box2D: https://github.com/erincatto/Box2D/issues/555