### PR TITLE
Added newer Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,34 +4,37 @@ env:
     - BUILD_COMMIT=$TRAVIS_COMMIT
     - PLAT=x86_64
 
-install: 
-  - git clone https://github.com/matthew-brett/multibuild
+install:
+  - git clone https://github.com/multi-build/multibuild
   - . multibuild/common_utils.sh
   - . multibuild/travis_steps.sh
-  - before_install 
+  - before_install
   # - clean_code $REPO_DIR $BUILD_COMMIT
   - build_wheel $REPO_DIR $PLAT
-script: 
+script:
   - install_run $PLAT
 
 after_success:
   - ./deploy.sh
 
-    
 matrix:
   include:
 
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.5
-    
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.6
- 
+
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
+
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.9
 
 
     - os: osx
@@ -39,15 +42,25 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.5
         - DEPLOY_SDIST=true
- 
+
     - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
- 
+
     - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
- 
- 
+
+    - os: osx
+      osx_image: xcode8.3
+      env:
+        - MB_PYTHON_VERSION=3.8
+
+        - os: osx
+      osx_image: xcode8.3
+      env:
+        - MB_PYTHON_VERSION=3.9
+
+


### PR DESCRIPTION
Hi, I was trying to use gym on a newer Python version and it failed because wheels were not available for 3.8. 

I know this package has not been updated for 3 years but could you please consider adding pre-build wheels for new python versions, 3.5 and 3.6 are already deprecated on most systems and nowadays is common to find Python 3.8 onwards. 

Added Python versions up to 3.9 and dropped 3.5 as it is no longer supported by the multilinux image used to build the wheels.

Modified multibuild repo URL, the one in place had an incorrect URL. Fixed in:
https://github.com/multi-build/multibuild/pull/484